### PR TITLE
Make service and action display format consistent

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -776,7 +776,7 @@ class Statement:
                             match_found = True
                     if not match_found:
                         self.add_finding(
-                            "No resources match for {}.{} which requires a resource format of *".format(
+                            "No resources match for {}:{} which requires a resource format of *".format(
                                 action_struct["service"],
                                 action_struct["action"]
                             ),

--- a/tests/unit/test_patterns.py
+++ b/tests/unit/test_patterns.py
@@ -124,7 +124,7 @@ class TestPatterns(unittest.TestCase):
         )
         print(policy.findings)
 
-        # There is one finding for "No resources match for s3.ListAllMyBuckets which requires a resource format of *"
+        # There is one finding for "No resources match for s3:ListAllMyBuckets which requires a resource format of *"
         assert_true(
             len(policy.findings) == 1,
             "Buckets do not match so no escalation possible",


### PR DESCRIPTION
I noticed inconsistent output for certain actions vs others (`service:Action` in some cases, `service.Action` in others) => 

```
INVALID - No resources match for s3.CreateJob which requires a resource format of * - {'filepath': None}
INVALID - No resources match for s3:DescribeJob which requires a resource format of arn:*:s3:*:*:job/* for the resource job* - {'filepath': None}
INVALID - No resources match for s3.GetAccountPublicAccessBlock which requires a resource format of * - {'filepath': None}
INVALID - No resources match for s3.ListAllMyBuckets which requires a resource format of * - {'filepath': None}
INVALID - No resources match for s3.ListJobs which requires a resource format of * - {'filepath': None}
INVALID - No resources match for s3.PutAccountPublicAccessBlock which requires a resource format of * - {'filepath': None}
INVALID - No resources match for s3:UpdateJobPriority which requires a resource format of arn:*:s3:*:*:job/* for the resource job* - {'filepath': None}
INVALID - No resources match for s3:UpdateJobStatus which requires a resource format of arn:*:s3:*:*:job/* for the resource job* - {'filepath': None}
```

I don't think it's desired to have the different format in those cases, so I presume it is a bug. I personally prefer the `service:Action` format, since it matches IAM policy docs format