### PR TITLE
Fix typo "resouces" => resources

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -576,7 +576,7 @@ class Statement:
         If it is maformed, return False
         """
         actions = []
-        resouces = []
+        resources = []
         conditions = []
 
         # Check no unknown elements exist


### PR DESCRIPTION
Seems like no real harm as currently coded, but good to fix the typo anyway :) 