### PR TITLE
Added `get_allowed_actions` and unit tests. Fixes #58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,10 @@ utils/docs/
 *.egg-info
 .eggs
 venv/
+.venv/
 .coverage
 htmlcov/
 dist/
 parliament/private_auditors
+.idea/*
+.vscode/*

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,8 @@ setup(
     install_requires=[
         'boto3',
         'jmespath',
-        'pyyaml'
+        'pyyaml',
+        'policy_sentry'
     ],
     setup_requires=['nose'],
     packages=find_packages(exclude=['tests*']),

--- a/tests/unit/test_get_allowed_actions.py
+++ b/tests/unit/test_get_allowed_actions.py
@@ -1,0 +1,26 @@
+import unittest
+
+from parliament import analyze_policy_string
+
+
+class TestGetAllowedActions(unittest.TestCase):
+    """Test class for get_allowed_actions"""
+
+    def test_allowed_actions_simple(self):
+        """test_allowed_actions_simple: Get a list of actions allowed by an IAM policy."""
+        policy = analyze_policy_string(
+            """{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Effect":"Allow",
+      "Action":["cloud9:update*"],
+      "Resource":["*"]
+    }
+  ]
+}"""
+        )
+        allowed_actions = policy.get_allowed_actions()
+        self.maxDiff = None
+        desired_result = ['cloud9:updateenvironment', 'cloud9:updateenvironmentmembership', 'cloud9:updateusersettings']
+        self.assertListEqual(allowed_actions, desired_result)


### PR DESCRIPTION
Fixes #58. It leverages relevant functions from policy sentry to get a full list of IAM actions that are allowed by the policy.

This way, you can call Parliament as a library and just run policy.get_allowed_actions to get a full list of actions that are allowed by the policy. See the unit tests for an example.