### PR TITLE
Created requirements.txt file and added Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ venv/
 .coverage
 htmlcov/
 dist/
+.env/
 parliament/private_auditors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+    - "3.7"
+    - "3.8"
+install: make setup
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+setup:
+	pip install -r requirements.txt
+test:
+	bash tests/scripts/unit_tests.sh

--- a/README.md
+++ b/README.md
@@ -237,12 +237,12 @@ for f in analyzed_policy.findings:
 Setup a testing environment
 ```
 python3 -m venv ./venv && source venv/bin/activate
-pip3 install boto3 jmespath pyyaml nose coverage beautifulsoup4 requests
+pip3 install -r requirements.txt
 ```
 
 Run unit tests with:
 ```
-./tests/scripts/unit_tests.sh
+make test
 ```
 
 Run locally as:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+beautifulsoup4==4.8.2
+boto3==1.11.9
+botocore==1.14.9
+certifi==2019.11.28
+chardet==3.0.4
+coverage==5.0.3
+docutils==0.15.2
+idna==2.8
+jmespath==0.9.4
+nose==1.3.7
+python-dateutil==2.8.1
+PyYAML==5.3
+requests==2.22.0
+s3transfer==0.3.2
+six==1.14.0
+soupsieve==1.9.5
+urllib3==1.25.8


### PR DESCRIPTION
Hey @0xdabbad00,

Here's a PR that aims to add TravisCI integration for parliament.

Specifically, I've created a requirements.txt file by creating a new venv, installing the requirements you listed, then `pip freeze > requirements.txt` so that only those requirements and their dependencies are included.

I've created a .travis.yml file which tells Travis CI to install the requirements and run the tests for both Python 3.7 and 3.8. More information can be found [here](https://docs.travis-ci.com/user/languages/python/).

Finally, I created a Makefile to make installation and testing easier. Note that I adjusted it to use the standard environment since we're already telling folks to use a venv in the readme. I then updated the README to match the new changes.

I can't guarantee this will work the first time, but 🤞 