### PR TITLE
add note about Paco using Parliament

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,4 @@ The IAM data is obtained from scraping the docs [here](https://docs.aws.amazon.c
 - [CloudMapper](https://github.com/duo-labs/cloudmapper): Has functionality to audit AWS environments and will audit the IAM policies as part of that.
 - [tf-parliament](https://github.com/rdkls/tf-parliament): Runs Parliament against terraform files
 - [iam-lint](https://github.com/xen0l/iam-lint): Github action for linting AWS IAM policy documents 
+- [Paco](https://paco-cloud.io): Cloud orchestration tool that integrates Parliament as a library to verify a project's IAM Policies and warns about findings.


### PR DESCRIPTION
I integrated Parliament as a library into Paco. One of Paco's goals is to validate and verify as much configuration as it can before it actually goes and makes changes to AWS. This library works great for helping with that :)