### PR TITLE
Ship config_override.yaml from parliament/community_auditors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ setup(
     install_requires=["boto3", "jmespath", "pyyaml", "policy_sentry"],
     setup_requires=["nose"],
     packages=find_packages(exclude=["tests*"]),
-    package_data={"parliament": ["iam_definition.json", "config.yaml"]},
+    package_data={
+        "parliament": ["iam_definition.json", "config.yaml"],
+        "parliament.community_auditors": ["config_override.yaml"],
+    },
     zip_safe=True,
     license="BSD 3",
     keywords="aws parliament iam lint audit",


### PR DESCRIPTION
This PR fixes #90 as latest published version of parliament misses config_override.yaml from parliament/community_auditors directory.

Output from `python setup.py sdist`:
```
running sdist
running egg_info
writing parliament.egg-info/PKG-INFO
writing dependency_links to parliament.egg-info/dependency_links.txt
writing entry points to parliament.egg-info/entry_points.txt
writing requirements to parliament.egg-info/requires.txt
writing top-level names to parliament.egg-info/top_level.txt
reading manifest file 'parliament.egg-info/SOURCES.txt'
writing manifest file 'parliament.egg-info/SOURCES.txt'
running check
creating parliament-0.4.8
creating parliament-0.4.8/parliament
creating parliament-0.4.8/parliament.egg-info
creating parliament-0.4.8/parliament/community_auditors
copying files to parliament-0.4.8...
copying README.md -> parliament-0.4.8
copying setup.cfg -> parliament-0.4.8
copying setup.py -> parliament-0.4.8
copying parliament/__init__.py -> parliament-0.4.8/parliament
copying parliament/cli.py -> parliament-0.4.8/parliament
copying parliament/config.yaml -> parliament-0.4.8/parliament
copying parliament/finding.py -> parliament-0.4.8/parliament
copying parliament/iam_definition.json -> parliament-0.4.8/parliament
copying parliament/misc.py -> parliament-0.4.8/parliament
copying parliament/policy.py -> parliament-0.4.8/parliament
copying parliament/statement.py -> parliament-0.4.8/parliament
copying parliament.egg-info/PKG-INFO -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/SOURCES.txt -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/dependency_links.txt -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/entry_points.txt -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/requires.txt -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/top_level.txt -> parliament-0.4.8/parliament.egg-info
copying parliament.egg-info/zip-safe -> parliament-0.4.8/parliament.egg-info
copying parliament/community_auditors/__init__.py -> parliament-0.4.8/parliament/community_auditors
copying parliament/community_auditors/config_override.yaml -> parliament-0.4.8/parliament/community_auditors
copying parliament/community_auditors/credentials_exposure.py -> parliament-0.4.8/parliament/community_auditors
copying parliament/community_auditors/permissions_management.py -> parliament-0.4.8/parliament/community_auditors
copying parliament/community_auditors/privilege_escalation.py -> parliament-0.4.8/parliament/community_auditors
Writing parliament-0.4.8/setup.cfg
Creating tar archive
removing 'parliament-0.4.8' (and everything under it)
```