### PR TITLE
performance: making parliament 100 times faster on long policies

### DIFF
--- a/parliament/__init__.py
+++ b/parliament/__init__.py
@@ -8,6 +8,7 @@ import json
 import yaml
 import re
 import fnmatch
+import functools
 import pkg_resources
 
 # On initialization, load the IAM data
@@ -171,6 +172,7 @@ def is_glob_match(s1, s2):
     return s1[0] == s2[0] and is_glob_match(s1[1:], s2[1:])
 
 
+@functools.lru_cache(maxsize=1024)
 def expand_action(action, raise_exceptions=True):
     """
     Converts "iam:*List*" to


### PR DESCRIPTION
I noticed that parliament's analysis is very slow on policies with many actions, profiling showed that the function `expand_action` is called millions of times with the same arguments. I added `lru_cache` for the function it resulted in a great improvement from ~20 seconds to ~110ms on my machine.
I thought it would be useful for all.

Here's how to reproduce the issue:
```python
from parliament import Policy

policy_doc = {
    "Statement": [
        {
            "Action": [
                "autoscaling:CreateOrUpdateTags",
                "autoscaling:DeleteAutoScalingGroup",
                "autoscaling:DeleteLaunchConfiguration",
                "autoscaling:DeleteTags",
                "autoscaling:DescribeLaunchConfigurations",
                "autoscaling:ResumeProcesses",
                "autoscaling:SuspendProcesses",
                "autoscaling:UpdateAutoScalingGroup",
                "cloudWatch:PutMetricData",
                "cloudfront:UpdateDistribution",
                "cloudtrail:CreateTrail",
                "cloudtrail:DescribeTrails",
                "cloudtrail:GetEventSelectors",
                "cloudtrail:GetTrailStatus",
                "cloudwatch:DeleteAlarms",
                "cloudwatch:DescribeAlarmsForMetric",
                "cloudwatch:GetMetricStatistics",
                "config:DescribeConfigurationRecorderStatus",
                "config:DescribeConfigurationRecorders",
                "config:DescribeDeliveryChannels",
                "config:GetResourceConfigHistory",
                "dynamodb:DeleteTable",
                "dynamodb:ListTagsOfResource",
                "dynamodb:TagResource",
                "dynamodb:UntagResource",
                "ec2:AssociateIamInstanceProfile",
                "ec2:AuthorizeSecurityGroupEgress",
                "ec2:AuthorizeSecurityGroupIngress",
                "ec2:CopySnapshot",
                "ec2:CreateSnapshot",
                "ec2:CreateTags",
                "ec2:DeleteNatGateway",
                "ec2:DeleteSecurityGroup",
                "ec2:DeleteSnapshot",
                "ec2:DeleteTags",
                "ec2:DeleteVolume",
                "ec2:DeregisterImage",
                "ec2:DescribeFlowLogs",
                "ec2:DescribeImages",
                "ec2:DescribeInstanceStatus",
                "ec2:DescribeInstances",
                "ec2:DescribePrefixLists",
                "ec2:DescribeRouteTables",
                "ec2:DescribeSecurityGroups",
                "ec2:DescribeSnapshotAttribute",
                "ec2:DescribeSnapshots",
                "ec2:DescribeStaleSecurityGroups",
                "ec2:DescribeSubnets",
                "ec2:DescribeTags",
                "ec2:DescribeVolumes",
                "ec2:DescribeVpcs",
                "ec2:DetachVolume",
                "ec2:DisassociateIamInstanceProfile",
                "ec2:ModifyInstanceAttribute",
                "ec2:ModifyNetworkInterfaceAttribute",
                "ec2:ModifyVolumeAttribute",
                "ec2:ResetImageAttribute",
                "ec2:RevokeSecurityGroupEgress",
                "ec2:RevokeSecurityGroupIngress",
                "ec2:StartInstances",
                "ec2:StopInstances",
                "ec2:TerminateInstances",
                "ecr:GetRepositoryPolicy",
                "ecr:SetRepositoryPolicy",
                "elasticache:CreateSnapshot",
                "elasticache:DeleteCacheCluster",
                "elasticache:DeleteReplicationGroup",
                "elasticache:DeleteSnapshot",
                "elasticache:ListTagsForResource",
                "elasticache:ModifyReplicationGroup",
                "health:DescribeAffectedEntities",
                "health:DescribeEventDetails",
                "health:DescribeEvents",
                "iam:DeleteAccessKey",
                "iam:GenerateCredentialReport",
                "iam:GetAccountPasswordPolicy",
                "iam:GetAccountSummary",
                "iam:GetCredentialReport",
                "iam:GetGroup",
                "iam:ListAccessKeys",
                "iam:ListAccountAliases",
                "iam:ListAttachedRolePolicies",
                "iam:ListAttachedUserPolicies",
                "iam:ListGroupPolicies",
                "iam:ListGroupsForUser",
                "iam:ListMFADevices",
                "iam:ListPolicies",
                "iam:ListPolicyVersions",
                "iam:ListRolePolicies",
                "iam:ListVirtualMFADevices",
                "iam:UpdateAccessKey",
                "lambda:DeleteFunction",
                "lambda:GetPolicy",
                "lambda:InvokeFunction",
                "lambda:RemovePermission",
                "lambda:TagResource",
                "lambda:UntagResource",
                "logs:DeleteLogGroup",
                "logs:DescribeLogStreams",
                "logs:PutRetentionPolicy",
                "rds:AddTagsToResource",
                "rds:CopyDBSnapshot",
                "rds:CreateDBSnapshot",
                "rds:DeleteDBInstance",
                "rds:DeleteDBSnapshot",
                "rds:DescribeDBEngineVersions",
                "rds:DescribeDBInstances",
                "rds:DescribeDBParameters",
                "rds:DescribeDBSnapshotAttributes",
                "rds:DescribeDBSnapshots",
                "rds:ModifyDBCluster",
                "rds:ModifyDBInstance",
                "rds:ModifyDBParameterGroup",
                "rds:RebootDBInstance",
                "rds:RemoveTagsFromResource",
                "s3:DeleteBucketPolicy",
                "s3:DeleteBucketWebsite",
                "s3:GetBucketNotification",
                "s3:GetBucketPolicy",
                "s3:GetInventoryConfiguration",
                "s3:GetObject",
                "s3:ListAllMyBuckets",
                "s3:ListBucket",
                "s3:PutBucketAcl",
                "s3:PutBucketLogging",
                "s3:PutBucketNotification",
                "s3:PutBucketPolicy",
                "s3:PutBucketVersioning",
                "s3:PutInventoryConfiguration",
                "s3:PutObject",
                "shield:CreateSubscription",
                "shield:DeleteSubscription",
                "shield:DescribeSubscription",
                "sns:*",
                "sqs:DeleteQueue",
                "sqs:GetQueueAttributes",
                "sqs:ListQueues",
                "sqs:SetQueueAttributes",
                "sts:AssumeRole",
                "support:*",
                "waf-regional:AssociateWebACL",
                "waf-regional:ListResourcesForWebACL",
                "waf-regional:ListWebACLs",
                "waf:ListWebACLs",
            ],
            "Effect": "Allow",
            "Resource": "*",
            "Sid": "VisualEditor0",
        },
        {
            "Action": "sqs:*",
            "Effect": "Allow",
            "Resource": "arn:aws:sqs:*:*:*",
            "Sid": "VisualEditor1",
        },
    ],
    "Version": "2012-10-17",
}

start = time.time()

policy = Policy(policy_doc)
valid = policy.analyze(include_community_auditors=True)

end = time.time()
print(f"{end - start = }")

```