### PR TITLE
Add check for warning about user-defined sensitive access

### DIFF
--- a/parliament/__init__.py
+++ b/parliament/__init__.py
@@ -3,13 +3,13 @@ This library is a linter for AWS IAM policies.
 """
 __version__ = "0.4.12"
 
-import os
-import json
-import yaml
-import re
 import fnmatch
 import functools
+import json
+import re
+
 import pkg_resources
+import yaml
 
 # On initialization, load the IAM data
 iam_definition_path = pkg_resources.resource_filename(__name__, "iam_definition.json")
@@ -52,6 +52,7 @@ def analyze_policy_string(
     ignore_private_auditors=False,
     private_auditors_custom_path=None,
     include_community_auditors=False,
+    config=None,
 ):
     """Given a string reperesenting a policy, convert it to a Policy object with findings"""
 
@@ -63,7 +64,7 @@ def analyze_policy_string(
         policy.add_finding("MALFORMED_JSON", detail="json parsing error: {}".format(e))
         return policy
 
-    policy = Policy(policy_json, filepath)
+    policy = Policy(policy_json, filepath, config)
     policy.analyze(
         ignore_private_auditors,
         private_auditors_custom_path,

--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -13,6 +13,7 @@ from parliament import (
     analyze_policy_string,
     enhance_finding,
     override_config,
+    config,
     __version__,
 )
 from parliament.misc import make_list
@@ -214,6 +215,16 @@ def main():
     exit_status = 0
     findings = []
 
+    if args.include_community_auditors:
+        community_auditors_directory = "community_auditors"
+        community_auditors_override_file = (
+            Path(abspath(__file__)).parent
+            / community_auditors_directory
+            / "config_override.yaml"
+        )
+        override_config(community_auditors_override_file)
+    override_config(args.config)
+
     if args.aws_managed_policies:
         file_paths = find_files(directory=args.aws_managed_policies)
         for file_path in file_paths:
@@ -228,6 +239,7 @@ def main():
                     file_path,
                     private_auditors_custom_path=args.private_auditors,
                     include_community_auditors=args.include_community_auditors,
+                    config=config,
                 )
                 findings.extend(policy.findings)
 
@@ -266,6 +278,7 @@ def main():
                         user["Arn"],
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
+                        config=config,
                     )
                     findings.extend(policy.findings)
             for role in auth_details_json["RoleDetailList"]:
@@ -275,6 +288,7 @@ def main():
                         role["Arn"],
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
+                        config=config,
                     )
                     findings.extend(policy.findings)
             for group in auth_details_json["GroupDetailList"]:
@@ -284,6 +298,7 @@ def main():
                         group["Arn"],
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
+                        config=config,
                     )
                     findings.extend(policy.findings)
     elif args.string:
@@ -291,6 +306,7 @@ def main():
             args.string,
             private_auditors_custom_path=args.private_auditors,
             include_community_auditors=args.include_community_auditors,
+            config=config,
         )
         findings.extend(policy.findings)
     elif args.file:
@@ -301,6 +317,7 @@ def main():
                 args.file,
                 private_auditors_custom_path=args.private_auditors,
                 include_community_auditors=args.include_community_auditors,
+                config=config,
             )
             findings.extend(policy.findings)
     elif args.directory:
@@ -317,6 +334,7 @@ def main():
                     file_path,
                     private_auditors_custom_path=args.private_auditors,
                     include_community_auditors=args.include_community_auditors,
+                    config=config,
                 )
                 findings.extend(policy.findings)
     else:
@@ -324,15 +342,6 @@ def main():
         exit(-1)
 
     filtered_findings = []
-    override_config(args.config)
-    if args.include_community_auditors:
-        community_auditors_directory = "community_auditors"
-        community_auditors_override_file = (
-            Path(abspath(__file__)).parent
-            / community_auditors_directory
-            / "config_override.yaml"
-        )
-        override_config(community_auditors_override_file)
     for finding in findings:
         finding = enhance_finding(finding)
         if not is_finding_filtered(finding, args.minimum_severity):

--- a/parliament/community_auditors/config_override.yaml
+++ b/parliament/community_auditors/config_override.yaml
@@ -15,3 +15,12 @@ CREDENTIALS_EXPOSURE:
   description: Policy grants access to API calls that can return credentials to the user
   severity: MEDIUM
   group: CUSTOM
+
+SENSITIVE_ACCESS:
+  title: Sensitive resource access check
+  description: Policy contains sensitive operation and resource access
+  severity: HIGH
+  group: CUSTOM
+  # Resource definitions have to be in the format:
+  # - 'service:action': [afn1, arn2]
+  resources: []

--- a/parliament/community_auditors/credentials_exposure.py
+++ b/parliament/community_auditors/credentials_exposure.py
@@ -1,5 +1,3 @@
-from parliament import is_arn_match, expand_action
-
 # https://gist.github.com/kmcquade/33860a617e651104d243c324ddf7992a
 CREDENTIALS_EXPOSURE_ACTIONS = [
     "codepipeline:pollforjobs",

--- a/parliament/community_auditors/permissions_management.py
+++ b/parliament/community_auditors/permissions_management.py
@@ -1,6 +1,3 @@
-from parliament import is_arn_match, expand_action
-
-
 def audit(policy):
     # The following list is obtained from Policy Sentry via the following code.
     # This is done to avoid pulling in Policy Sentry and its requirements which adds ~50MB to this library.

--- a/parliament/community_auditors/sensitive_access.py
+++ b/parliament/community_auditors/sensitive_access.py
@@ -1,0 +1,43 @@
+from collections import defaultdict
+
+from parliament import is_arn_match, expand_action
+
+
+def _expand_action(operation):
+    data = expand_action(operation)[0]
+
+    return "{}:{}".format(data["service"], data["action"])
+
+
+def audit(policy):
+    allowed_actions = policy.get_allowed_actions()
+
+    try:
+        config_resources = policy.config["SENSITIVE_ACCESS"]["resources"]
+    except KeyError:
+        config_resources = {}
+
+    sensitive_resources = defaultdict(list)
+    for item in config_resources:
+        action = list(item.keys())[0]
+        expanded_action = _expand_action(action)
+        resources = list(item.values())[0]
+
+        sensitive_resources[expanded_action].extend(resources)
+
+    action_resources = {}
+    for action in allowed_actions:
+        expanded_action = _expand_action(action)
+        service, operation = expanded_action.split(":")
+        action_resources[expanded_action] = policy.get_allowed_resources(
+            service, operation
+        )
+
+    for action in action_resources:
+        for action_resource in action_resources[action]:
+            for sensitive_resource in sensitive_resources[action]:
+                if is_arn_match("object", action_resource, sensitive_resource):
+                    policy.add_finding(
+                        "SENSITIVE_ACCESS",
+                        location={"resource": action_resource, "actions": action},
+                    )

--- a/parliament/community_auditors/tests/test_credentials_exposure.py
+++ b/parliament/community_auditors/tests/test_credentials_exposure.py
@@ -1,5 +1,6 @@
 import unittest
-from nose.tools import raises, assert_equal
+
+from nose.tools import assert_equal
 
 # import parliament
 from parliament import analyze_policy_string
@@ -30,5 +31,11 @@ class TestCredentialsManagement(unittest.TestCase):
 
         assert_equal(
             policy.finding_ids,
-            set(["CREDENTIALS_EXPOSURE", "PERMISSIONS_MANAGEMENT_ACTIONS", "RESOURCE_STAR"]),
+            set(
+                [
+                    "CREDENTIALS_EXPOSURE",
+                    "PERMISSIONS_MANAGEMENT_ACTIONS",
+                    "RESOURCE_STAR",
+                ]
+            ),
         )

--- a/parliament/community_auditors/tests/test_permissions_management.py
+++ b/parliament/community_auditors/tests/test_permissions_management.py
@@ -1,5 +1,6 @@
 import unittest
-from nose.tools import raises, assert_equal
+
+from nose.tools import assert_equal
 
 # import parliament
 from parliament import analyze_policy_string
@@ -35,7 +36,7 @@ class TestPermissionsManagement(unittest.TestCase):
                 [
                     "PERMISSIONS_MANAGEMENT_ACTIONS",
                     "RESOURCE_POLICY_PRIVILEGE_ESCALATION",
-                    "RESOURCE_STAR"
+                    "RESOURCE_STAR",
                 ]
             ),
         )

--- a/parliament/community_auditors/tests/test_privilege_escalation.py
+++ b/parliament/community_auditors/tests/test_privilege_escalation.py
@@ -1,5 +1,6 @@
 import unittest
-from nose.tools import raises, assert_equal
+
+from nose.tools import assert_equal
 
 # import parliament
 from parliament import analyze_policy_string

--- a/parliament/community_auditors/tests/test_sensitive_access.py
+++ b/parliament/community_auditors/tests/test_sensitive_access.py
@@ -1,0 +1,43 @@
+import unittest
+
+from nose.tools import assert_equal
+
+from parliament import analyze_policy_string
+
+
+class TestSensitiveAccess(unittest.TestCase):
+    """Test class for Sensitive access auditor"""
+
+    def setUp(self) -> None:
+        self.config = {
+            "SENSITIVE_ACCESS": {
+                "resources": [{"s3:GetObject": ["arn:aws:s3:::secret*"]}]
+            }
+        }
+
+    def test_sensitive_access(self) -> None:
+        example_policy_string = """
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Resource": "arn:aws:s3:::secretbucket/*"
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:PutObject"
+              ],
+              "Resource": "arn:aws:s3:::otherbucket/*"
+            }
+          ]
+        }
+        """
+        policy = analyze_policy_string(
+            example_policy_string, include_community_auditors=True, config=self.config
+        )
+        assert_equal(policy.finding_ids, set(["SENSITIVE_ACCESS"]))

--- a/parliament/finding.py
+++ b/parliament/finding.py
@@ -1,6 +1,3 @@
-import yaml
-
-
 class Finding:
     """ Class for storing findings """
 

--- a/parliament/policy.py
+++ b/parliament/policy.py
@@ -1,15 +1,14 @@
-import json
-import pkgutil
 import importlib
-import os
-import sys
 import logging
+import os
+import pkgutil
+import sys
 from pathlib import Path
 
 from . import expand_action
-from .statement import Statement
 from .finding import Finding
-from .misc import make_list, ACCESS_DECISION
+from .misc import make_list
+from .statement import Statement
 
 
 class Policy:
@@ -19,11 +18,12 @@ class Policy:
     statements = []
     policy = None
 
-    def __init__(self, policy_json, filepath=None):
+    def __init__(self, policy_json, filepath=None, config=None):
         self._findings = []
         self.statements = []
         self.policy_json = policy_json
         self.filepath = filepath
+        self.config = config if config else {}
 
     def add_finding(self, finding, detail="", location={}):
         if "filepath" not in location:

--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -1,6 +1,4 @@
-import os
 import json
-import fnmatch
 import re
 
 from . import (
@@ -11,7 +9,7 @@ from . import (
     UnknownPrefixException,
 )
 from .finding import Finding
-from .misc import make_list, ACCESS_DECISION
+from .misc import make_list
 
 
 def is_condition_key_match(document_key, str):


### PR DESCRIPTION
This PR adds community auditor that takes user-provided config values and checks policies for presence of sensitive action/resource. 

Some hilights:
* policy object now takes config as an argument when instantiating the object. This allows to pass in config contents to check itself
* I removed unused imports