### PR TITLE
Gracefully handle resources with cloudformation concepts

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -754,7 +754,20 @@ class Statement:
         for resource in resources:
             if resource == "*":
                 continue
-            parts = resource.split(":")
+            try:
+                parts = resource.split(":")
+            except AttributeError:
+                has_malformed_resource = True
+                self.add_finding(
+                    "INVALID_ARN",
+                    detail=(
+                        "Must be a string. Maybe you're trying to analyze a "
+                        "CloudFormation template which is outside of Parliament's "
+                        "scope."
+                    ),
+                    location={"string": resource},
+                )
+                continue
             if len(parts) < 6:
                 has_malformed_resource = True
                 self.add_finding(

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -1,0 +1,25 @@
+import unittest
+from nose.tools import assert_equal
+
+from parliament import analyze_policy_string
+
+
+class TestResources(unittest.TestCase):
+    """Test class for principals"""
+
+    def test_resource_with_sub(self):
+        policy = analyze_policy_string(
+            """{
+  "Version":"2012-10-17",
+  "Statement":[
+    {
+      "Sid":"AddPerm",
+      "Effect":"Allow",
+      "Principal": "*",
+      "Action":["ssm:PutParameter"],
+      "Resource":[{"Fn::Sub": "arn:aws:ssm:*:${AWS::AccountId}:*"}]
+    }
+  ]
+}"""
+        )
+        assert_equal(policy.finding_ids, {"INVALID_ARN"})


### PR DESCRIPTION
Parliament fails with an AttributeError when analyzing a policy with this resource: `{"Fn::Sub": "arn:aws:ssm:*:${AWS::AccountId}:*"}`.

From the linked issue:

> Having a more helpful error message here and avoiding Parliament from crashing would be good though.

This PR tries to provide that. :)

Closes duo-labs/parliament#120