### PR TITLE
Only report RESOURCE_STAR finding once per statement

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -260,6 +260,7 @@ def translate_documentation_types(str):
 class Statement:
     findings = []
     effect_allow = True
+    resource_star = False
     stmt = None
     policy_id = None
 
@@ -862,7 +863,8 @@ class Statement:
                     # At least one resource has to match the action's required resources
                     match_found = False
                     for resource in resources:
-                        if resource == "*":
+                        if resource == "*" and not self.resource_star:
+                            self.resource_star = True
                             self.add_finding(
                                 "RESOURCE_STAR", location={"actions": actions},
                             )


### PR DESCRIPTION
This removes the tons of duplicate RESOURCE_STAR findings that occur when a statement has multiple actions and when wildcard actions get expanded.  I have had instances with hundreds of this finding for the same statement.