### PR TITLE
Fix ARN validation where empty segments were always considered valid

### DIFF
--- a/parliament/__init__.py
+++ b/parliament/__init__.py
@@ -128,9 +128,9 @@ def is_arn_match(resource_type, arn_format, resource):
     # For the first 5 parts (ex. arn:aws:SERVICE:REGION:ACCOUNT:), ensure these match appropriately
     # We do this because we don't want "arn:*:s3:::*/*" and "arn:aws:logs:*:*:/aws/cloudfront/*" to return True
     for position in range(0, 5):
-        if arn_parts[position] == "*" or arn_parts[position] == "":
+        if arn_parts[position] == "*" and resource_parts[position] != "":
             continue
-        elif resource_parts[position] == "*" or resource_parts[position] == "":
+        elif resource_parts[position] == "*":
             continue
         elif arn_parts[position] == resource_parts[position]:
             continue

--- a/tests/unit/test_resource_formatting.py
+++ b/tests/unit/test_resource_formatting.py
@@ -87,9 +87,82 @@ class TestResourceFormatting(unittest.TestCase):
             is_arn_match(
                 "cloudfront",
                 "arn:aws:logs:*:*:/aws/cloudfront/*",
-                "arn:aws:logs:us-east-1:000000000000:/aws/cloudfront/test",
+                "arn:aws:logs:us-east-1:000000000000:/aws/cloudfront/test"
             )
         )
+
+    def test_arn_match_cloudtrail_emptysegments(self):
+        assert_false(
+            is_arn_match(
+                "cloudtrail",
+                "arn:*:cloudtrail:*:*:trail/*",
+                "arn:::::trail/my-trail"
+            )
+        )
+
+    def test_arn_match_s3_withregion(self):
+        assert_false(
+            is_arn_match(
+                "object",
+                "arn:*:s3:::*/*",
+                "arn:aws:s3:us-east-1::bucket1/*"
+            )
+        )
+
+    def test_arn_match_s3_withaccount(self):
+        assert_false(
+            is_arn_match(
+                "object",
+                "arn:*:s3:::*/*",
+                "arn:aws:s3::123412341234:bucket1/*"
+            )
+        )
+
+    def test_arn_match_s3_withregion_account(self):
+        assert_false(
+            is_arn_match(
+                "object",
+                "arn:*:s3:::*/*",
+                "arn:aws:s3:us-east-1:123412341234:bucket1/*"
+            )
+        )
+
+    def test_arn_match_iam_emptysegments(self):
+        assert_false(
+            is_arn_match(
+                "role",
+                "arn:*:iam::*:role/*",
+                "arn:aws:iam:::role/my-role"
+            )
+        )
+
+    def test_arn_match_iam_withregion(self):
+        assert_false(
+            is_arn_match(
+                "role",
+                "arn:*:iam::*:role/*",
+                "arn:aws:iam:us-east-1::role/my-role"
+            )
+        )
+
+    def test_arn_match_apigw_emptysegments(self):
+        assert_false(
+            is_arn_match(
+                "apigateway",
+                "arn:*:apigateway:*::*",
+                "arn:aws:apigateway:::/restapis/a123456789/*"
+            )
+        )
+
+    def test_arn_match_apigw_withaccount(self):
+        assert_false(
+            is_arn_match(
+                "apigateway",
+                "arn:*:apigateway:*::*",
+                "arn:aws:apigateway:us-east-1:123412341234:/restapis/a123456789/*"
+            )
+        )
+
 
     def test_is_glob_match(self):
         tests = [


### PR DESCRIPTION
I opened this for discussion.  Empty segments seem to be correctly evaluated now.  I added the tests individually because I wanted them all to run.  Let me know what you think.  I can compress the tests together after your comfortable that this does not break anything else.