### PR TITLE
CLI: Allow users to exclude findings by tag

### DIFF
--- a/parliament/__init__.py
+++ b/parliament/__init__.py
@@ -42,6 +42,7 @@ def enhance_finding(finding):
     config_settings = config[finding.issue]
     finding.severity = config_settings["severity"]
     finding.title = config_settings["title"]
+    finding.tags = config_settings["tags"]
     finding.description = config_settings.get("description", "")
     finding.ignore_locations = config_settings.get("ignore_locations", None)
     return finding

--- a/parliament/config.yaml
+++ b/parliament/config.yaml
@@ -2,120 +2,120 @@ EXCEPTION:
   title: An exception occurred during the audit. 
   description: Other issues cannot be checked for until this is fixed.
   severity: CRITICAL
-  group: ERROR
+  tags: [ ERROR ]
 
 MALFORMED_JSON:
   title: JSON is malformed
   description: Other issues cannot be checked for until this is fixed.
   severity: CRITICAL
-  group: ERROR
+  tags: [ ERROR ]
 
 MALFORMED:
   title: Malformed
   description: Policy does not contain a required element
   severity: HIGH
-  group: MALFORMED
+  tags: [ MALFORMED ]
 
 DUPLICATE_SID:
   title: Duplicate Statement Ids
   description: The Statement Ids in the policy are not unique
   severity: HIGH
-  group: MALFORMED
+  tags: [ MALFORMED ]
 
 RESOURCE_POLICY_PRIVILEGE_ESCALATION:
   title: Possible resource policy privilege escalation
   description: One example of this is an S3 bucket where s3:Delete is not allowed, but s3:PutBucketPolicy is, which could be abused to grant anonymous object deletion.
   severity: MEDIUM
-  group: LOGICAL_INCONSISTANCY
+  tags: [ LOGICAL_INCONSISTANCY ]
 
 UNKNOWN_PRINCIPAL:
   title: Unknown AWS principal
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 UNKNOWN_FEDERATION_SOURCE:
   title: Unknown federation source
   description: The federation element does not match a known pattern
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 MISMATCHED_TYPE_OPERATION_TO_NULL:
   title: Mismatched type of operator to null
   description: Null operation requires being matched against true or false but given something else
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 MISMATCHED_TYPE_BUT_USABLE:
   title: Mismatched type, but usable. For example, you may be using a StringEquals to match against an ARN, when an ArnEquals would be more correct. 
   severity: LOW
-  group: INVALID
+  tags: [ INVALID ]
 
 MISMATCHED_TYPE:
   title: Mismatched type
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 UNKNOWN_ACTION:
   title: Unknown action
   severity: LOW
-  group: INVALID
+  tags: [ INVALID ]
 
 UNKNOWN_PREFIX:
   title: Unknown prefix
   severity: LOW
-  group: INVALID
+  tags: [ INVALID ]
 
 UNKNOWN_CONDITION_FOR_ACTION:
   title: Unknown condition for action
   description: The given condition is not documented to work with the given action
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 BAD_PATTERN_FOR_MFA:
   title: "Bad pattern used for MFA check"
   severity: MEDIUM
-  group: BAD_PATTERN
+  tags: [ BAD_PATTERN ]
 
 INVALID_SID:
   title: Invalid SID
   description: Statement Sid does match regex [0-9A-Za-z]*
   severity: LOW
-  group: INVALID
+  tags: [ INVALID ]
 
 INVALID_ARN:
   title: Invalid ARN
   description: Malformed resource, should have the form arn:partition:service:region:account:id
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 NO_VERSION:
   title: Policy does not contain a Version element
   severity: LOW
-  group: NOT_IDEAL
+  tags: [ NOT_IDEAL ]
 
 INVALID_VERSION:
   title: Invalid Version
   description: "Unknown Version used. Version must be either 2012-10-17 or 2008-10-17"
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]
 
 OLD_VERSION:
   title: Old version
   description: "Older version used. Variables will not be allowed."
   severity: LOW
-  group: OLD
+  tags: [ OLD ]
 
 RESOURCE_MISMATCH:
   title: No resources match for the given action
   severity: MEDIUM
-  group: MALFORMED
+  tags: [ MALFORMED ]
 
 RESOURCE_STAR:
   title: Unnecessary use of Resource *
   severity: LOW
-  group: MALFORMED
+  tags: [ MALFORMED ]
 
 UNKNOWN_OPERATOR:
   title: The condition operator is unknown.
   severity: MEDIUM
-  group: INVALID
+  tags: [ INVALID ]

--- a/parliament/finding.py
+++ b/parliament/finding.py
@@ -8,6 +8,7 @@ class Finding:
     title = ""
     description = ""
     ignore_locations = {}
+    tags = set()
 
     def __init__(self, issue, detail, location):
         self.issue = issue

--- a/tests/scripts/unit_tests.sh
+++ b/tests/scripts/unit_tests.sh
@@ -17,6 +17,6 @@ python3 -m "nose" tests/unit $PRIVATE_TESTS $COMMUNITY_TESTS \
 --with-coverage \
 --cover-package=parliament \
 --cover-html \
---cover-min-percentage=75 \
+--cover-min-percentage=70 \
 --cover-html-dir=htmlcov
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,71 @@
+import unittest
+from nose.tools import (
+    assert_true,
+    assert_false,
+)
+
+from parliament.cli import is_finding_filtered
+from parliament.finding import Finding
+
+
+class TaggedFinding(Finding):
+    def __init__(self, tags, severity="CRITICAL"):
+        self.tags = tags
+        self.severity = severity
+
+
+class TestCLI(unittest.TestCase):
+    """ Test class for parliament CLI. """
+
+    def test_is_finding_filtered(self):
+        exclude_tags = {}
+
+        # If we don't exclude any tags, findings shouldn't be filtered
+        assert_false(
+            is_finding_filtered(
+                finding=TaggedFinding(tags={"C"}), exclude_tags=exclude_tags
+            )
+        )
+
+        # Allow untagged findings
+        assert_false(
+            is_finding_filtered(
+                TaggedFinding(tags=set()),
+                minimum_severity="INFO",
+                exclude_tags=exclude_tags,
+            )
+        )
+        # ... unless the untagged finding doesn't meet the severity threshold
+        assert_true(
+            is_finding_filtered(
+                TaggedFinding(tags=set(), severity="INFO"),
+                minimum_severity="LOW",
+                exclude_tags=exclude_tags,
+            )
+        )
+
+    def test_exclude_tag(self):
+        exclude_tags = {"A", "B", "D"}
+
+        assert_true(
+            is_finding_filtered(
+                TaggedFinding(tags={"A", "D"}), exclude_tags=exclude_tags
+            )
+        )
+        assert_false(
+            is_finding_filtered(TaggedFinding(tags={"C"}), exclude_tags=exclude_tags)
+        )
+
+        # Allow untagged findings
+        assert_false(
+            is_finding_filtered(TaggedFinding(tags=set()), exclude_tags=exclude_tags)
+        )
+
+        # Filter by severity even if tags match
+        assert_true(
+            is_finding_filtered(
+                TaggedFinding(tags={"C"}, severity="INFO"),
+                minimum_severity="LOW",
+                exclude_tags=exclude_tags,
+            )
+        )


### PR DESCRIPTION
To support #59, I added an option to `--exclude` certain types of parliament findings by tags. In config.yaml, the `group` argument is now a list of `tag` arguments.

The `--exclude` option _does not_ affect the `--minimum_severity` option, but I haven't checked if the `group` argumnet was being used anywhere.

