### PR TITLE
Fix missing .value for NotAction

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -316,7 +316,7 @@ class Statement:
                 # I don't think it makes sense to have a "NotAction" of "*", but I'm including this check anyway.
                 return False
 
-            for action_struct in expand_action(action, raise_exceptions=False):
+            for action_struct in expand_action(action.value, raise_exceptions=False):
                 if (
                     action_struct["service"] == privilege_prefix
                     and action_struct["action"] == privilege_name


### PR DESCRIPTION
This fixes the error encountered when trying to run parliament on a PowerUsers-esque policy (assumedly any policy with a NotAction):

```
{
            "Statement": [
                {
                    "NotAction": "iam:*",
                    "Effect": "Allow",
                    "Resource": "*"
                },
            ],
            "Version": "2012-10-17"
}
```

```
FOUND ERROR: Expected a ConfigJSONObject but found ConfigJSONScalar. You are trying to get an item from a scalar as if it was an object. item=split [line=1;col=30]
```