### PR TITLE
fix node_exists checks

### DIFF
--- a/parliament/policy.py
+++ b/parliament/policy.py
@@ -241,7 +241,7 @@ class Policy:
             return False
 
         # Check Version
-        if not self.policy_json.node_exists("Version"):
+        if not jsoncfg.node_exists(self.policy_json["Version"]):
             self.add_finding("NO_VERSION")
         else:
             self.version = self.policy_json["Version"].value
@@ -256,7 +256,7 @@ class Policy:
                 self.add_finding("OLD_VERSION", location=self.policy_json["Version"])
 
         # Check Statements
-        if not self.policy_json.node_exists("Statement"):
+        if not jsoncfg.node_exists(self.policy_json["Statement"]):
             self.add_finding(
                 "MALFORMED", detail="Policy does not contain a Statement element"
             )


### PR DESCRIPTION
`jsoncfg` objects do not define a `node_exists` method, but they [override `__getattr__` with `__getitem__ `](https://github.com/pasztorpisti/json-cfg/blob/master/src/jsoncfg/config_classes.py#L285). This results in `self.policy_json.node_exists` not erroring out but returning a `ValueNotFoundNode` (because `jsoncfg` never raises key errors) and that for some reason [overrides `__call__`](https://github.com/pasztorpisti/json-cfg/blob/master/src/jsoncfg/config_classes.py#L155) with a method which ends up returning the first parameter passed.

TLDR, `self.policy_json.node_exists("Version")` would always return `"Version"`, hence passing the if-statement check. To fix this, it is simply enough to use the `jsoncfg.node_exists` utility function (which simply does a type check on the passed argument)

```
>>> import jsoncfg
>>> d = '{"foo": "bar"}'
>>> x = jsoncfg.loads_config(d)
>>> x.asd
<jsoncfg.config_classes.ValueNotFoundNode object at 0x10170ccd0>
>>> x.asd('123')
'123'
>>> jsoncfg.node_exists(x['foo'])
True
>>> jsoncfg.node_exists(x['none'])
False
```