### PR TITLE
Stop more checks if invalid resources are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This example is showing that the action s3:GetObject requires a resource matchin
 The different input types allowed include:
 - --file: Filename
 - --directory: A directory path, for exmaple: `--directory . --include_policy_extension json --exclude_pattern ".*venv.*"`
-- --aws-managed-policies: For use specifically with the repo https://github.com/SummitRoute/aws_managed_policies
+- --aws-managed-policies: For use specifically with the repo https://github.com/z0ph/aws_managed_policies
 - --auth-details-file: For use with the file returned by "aws iam get-account-authorization-details"
 - --string: Provide a string such as '{"Version": "2012-10-17","Statement": {"Effect": "Allow","Action": ["s3:GetObject", "s3:PutBucketPolicy"],"Resource": ["arn:aws:s3:::bucket1", "arn:aws:s3:::bucket2/*"]}}'
 

--- a/parliament/__init__.py
+++ b/parliament/__init__.py
@@ -32,8 +32,8 @@ def override_config(override_config_path):
     for finding_type, settings in override_config.items():
         if finding_type not in config:
             config[finding_type] = {}
-        for setting, settting_value in settings.items():
-            config[finding_type][setting] = settting_value
+        for setting, setting_value in settings.items():
+            config[finding_type][setting] = setting_value
 
 
 def enhance_finding(finding):

--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -641,7 +641,7 @@ class Statement:
         """
         Given a statement, look for problems and extract out the parts.
 
-        If it is maformed, return False
+        If it is malformed, return False
         """
         actions = []
         resources = []
@@ -955,4 +955,4 @@ class Statement:
                 "RESOURCE_STAR", detail=sorted(self.resource_star), location=self.stmt
             )
 
-        return True
+        return not has_malformed_resource


### PR DESCRIPTION
Analyzing a policy with an INVALID_ARN gives exceptions from all of the community auditors 

e.g.
```json
{
  "Version":"2012-10-17",
  "Statement":[
    {
      "Sid":"AddPerm",
      "Effect":"Allow",
      "Principal": "*",
      "Action":["ssm:PutParameter"],
      "Resource":[{"Fn::Sub": "arn:aws:ssm:*:${AWS::AccountId}:*"}]
    }
  ]
}
```
from [test_resources.py](https://github.com/duo-labs/parliament/blob/c7ea5b25c4b279036fbe773ecb179c9667ba66ea/tests/unit/test_resources.py#L12-L23)

Also:
* Update managed policies repo link to @z0ph's

* Fix some spelling