### PR TITLE
Statement: Find all unknown Actions and unknown Prefixes in a Statement

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -773,6 +773,7 @@ class Statement:
 
         # Expand the actions from s3:Get* to s3:GetObject and others
         expanded_actions = []
+        has_malformed_action = False
         for action in actions:
 
             # Handle special case where all actions are allowed
@@ -785,15 +786,22 @@ class Statement:
                 expanded_actions.extend(expand_action(action.value))
             except UnknownActionException as e:
                 self.add_finding(
-                    "UNKNOWN_ACTION", detail=str(e), location=action,
+                    "UNKNOWN_ACTION",
+                    detail=str(e),
+                    location=action,
                 )
-                return False
+                has_malformed_action = True
+                continue
             except UnknownPrefixException as e:
                 self.add_finding("UNKNOWN_PREFIX", detail=str(e), location=action)
-                return False
+                has_malformed_action = True
+                continue
             except Exception as e:
                 self.add_finding("EXCEPTION", detail=str(e), location=action)
                 return False
+
+        if has_malformed_action:
+            return False
 
         # Check the resources are correct formatted correctly
         has_malformed_resource = False


### PR DESCRIPTION
The primary use case of this change is for faster developer feedback. If there are two typo'd Actions in a single IAM Statement, parliament will only catch one; the user then makes a fix and then re-runs parliament to find the second issue. If there is a serious Exception with the Action syntax, we should still bail out and return False. However, UnknownAction and UnknownPrefix are recoverable and parliament should attempt to find all of them.

Here's a sample case that demonstrates the problem:
```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "cloudwatch:DescribeAlxarms",
        "elasticloadbalancing:DescribeRules",
        "cloudwatch:GetMetricDataForAccounts",
        "aaa:bbb",
        "logs:DescribeMetricFilters",
        "waf-regional:GetWebACLForResource"
      ],
      "Resource": "*",
      "Effect": "Allow"
    }
  ]
}
```

Unpatched, parliament would only find the first error with `cloudwatch:DescribeAlxarms`. With the patch, we would find the remaining errors in a single run of parliament.