### PR TITLE
Validate use of NotResource and NotAction based on AWS best practices

### DIFF
--- a/parliament/community_auditors/advanced_policy_elements.py
+++ b/parliament/community_auditors/advanced_policy_elements.py
@@ -1,0 +1,42 @@
+""" 
+For AWS resource policies, check whether they use discouraged constructions.
+See the [AWS Policy Troubleshooting Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_policies.html).
+
+AWS documentation discourages the use of NotPrincipal, NotAction and
+NotResource, particularly with Allow. These constructs, by default, grant 
+permissions, then Deny the ones explicitly listed. Instead, use an explicit 
+Resource, Action or Principal in your Allow list.
+"""
+
+from typing import Iterable
+
+import jsoncfg
+
+from parliament import Policy
+
+
+def get_stmts(policy: Policy) -> Iterable:
+    if "jsoncfg.config_classes.ConfigJSONObject" in str(
+        type(policy.policy_json.Statement)
+    ):
+        return [policy.policy_json.Statement]
+    elif "jsoncfg.config_classes.ConfigJSONArray" in str(
+        type(policy.policy_json.Statement)
+    ):
+        return policy.policy_json.Statement
+
+
+def audit(policy: Policy) -> None:
+    for stmt in get_stmts(policy):
+        if stmt.Effect.value == "Allow" and jsoncfg.node_exists(stmt["NotPrincipal"]):
+            # See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html#specifying-notprincipal-allow
+            policy.add_finding(
+                "NOTPRINCIPAL_WITH_ALLOW",
+                location=("NotPrincipal", stmt["NotPrincipal"]),
+            )
+        elif stmt.Effect.value == "Allow" and jsoncfg.node_exists(stmt["NotResource"]):
+            # See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html#notresource-element-combinations
+            policy.add_finding(
+                "NOTRESOURCE_WITH_ALLOW",
+                location=("NotResource", stmt["NotResource"]),
+            )

--- a/parliament/community_auditors/config_override.yaml
+++ b/parliament/community_auditors/config_override.yaml
@@ -24,3 +24,15 @@ SENSITIVE_ACCESS:
   # Resource definitions have to be in the format:
   # - 'service:action': [afn1, arn2]
   resources: []
+
+NOTPRINCIPAL_WITH_ALLOW:
+  title: NotPrincipal used with Allow effect
+  description: NotPrincipal with Allow automatically grants the permission to all principals, except the ones specified.
+  severity: MEDIUM
+  group: CUSTOM
+
+NOTRESOURCE_WITH_ALLOW:
+  title: NotResource used with Allow effect
+  description: NotResource with Allow automatically grants the Principal all services and resources that are not explicitly listed
+  severity: MEDIUM
+  group: CUSTOM

--- a/parliament/community_auditors/tests/test_advanced_policy_elements.py
+++ b/parliament/community_auditors/tests/test_advanced_policy_elements.py
@@ -1,0 +1,92 @@
+import unittest
+
+from nose.tools import assert_equal
+
+from parliament import analyze_policy_string
+
+S3_STAR_FINDINGS = {"PERMISSIONS_MANAGEMENT_ACTIONS", "RESOURCE_MISMATCH"}
+
+
+class TestAdvancedPolicyElements(unittest.TestCase):
+    def test_notresource_allow(self):
+        # NotResource is OK with Effect: Deny. This denies access to
+        # all S3 buckets except Payroll buckets. This example is taken from
+        # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html
+        policystr = """{
+          "Version": "2012-10-17",
+          "Statement": {
+            "Effect": "Deny",
+            "Action": "s3:*",
+            "NotResource": [
+              "arn:aws:s3:::HRBucket/Payroll",
+              "arn:aws:s3:::HRBucket/Payroll/*"
+            ]
+          }
+        }"""
+
+        policy = analyze_policy_string(policystr, include_community_auditors=True)
+        assert_equal(policy.finding_ids, set())
+
+        # According to AWS documentation, "This statement is very dangerous,
+        # because it allows all actions in AWS on all resources except the
+        # HRBucket S3 bucket." See:
+        # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html#notresource-element-combinations
+        policystr = """{
+          "Version": "2012-10-17",
+          "Statement": {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "NotResource": [
+              "arn:aws:s3:::HRBucket/Payroll",
+              "arn:aws:s3:::HRBucket/Payroll/*"
+            ]
+          }
+        }"""
+
+        policy = analyze_policy_string(policystr, include_community_auditors=True)
+
+        assert_equal(policy.finding_ids, S3_STAR_FINDINGS | {"NOTRESOURCE_WITH_ALLOW"})
+
+    def test_notprincipal_allow(self):
+        # NotPrincipal is OK with Effect: Deny. This explcitly omits these
+        # users from the list of Principals denied access to this resource
+        # This example is taken from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html#specifying-notprincipal
+        policystr = """{
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Deny",
+            "NotPrincipal": {"AWS": [
+              "arn:aws:iam::444455556666:user/Bob",
+              "arn:aws:iam::444455556666:root"
+            ]},
+            "Action": "s3:*",
+            "Resource": [
+              "arn:aws:s3:::BUCKETNAME",
+              "arn:aws:s3:::BUCKETNAME/*"
+            ]
+          }]
+        }"""
+
+        policy = analyze_policy_string(policystr, include_community_auditors=True)
+
+        assert_equal(policy.finding_ids, set())
+
+        # This implicitly allows everyone _except_ Bob to access BUCKETNAME!
+        policystr = """{
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "NotPrincipal": {"AWS": [
+              "arn:aws:iam::444455556666:user/Bob",
+            ]},
+            "Action": "s3:*",
+            "Resource": [
+              "arn:aws:s3:::BUCKETNAME",
+              "arn:aws:s3:::BUCKETNAME/*"
+            ]
+          }]
+        }"""
+
+        policy = analyze_policy_string(policystr, include_community_auditors=True)
+
+        assert_equal(policy.finding_ids, S3_STAR_FINDINGS | {"NOTPRINCIPAL_WITH_ALLOW"})


### PR DESCRIPTION
This auditor validates two AWS policy elements, and gives the user feedback to align with AWS documentation best practices. `NotResource` and `NotAction` are difficult to write policies for correctly because they implicitly `Allow` access to everything that is not specified in the Statement, and then revoke access.

I chose to make these 1 PR because they are both considered "advanced" policy elements by AWS and using either with `'Effect': 'Allow'`are both explicitly discouraged in the documentation. However, `NotResource` is targeted towards identity-based policies, whereas `NotAction` is targeted towards resource-based policies and trust relationships. So, I would be open to splitting this up somehow, e.g. by putting the checks into different community auditors Py files. Or, if we aren't ready for parliament to check resource-based policies, then we can skip `NotAction` entirely.