### PR TITLE
Fix json-cfg syntax

### DIFF
--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -233,7 +233,7 @@ def main():
                 contents = f.read()
                 policy_file_json = jsoncfg.loads_config(contents)
                 policy_string = json.dumps(
-                    policy_file_json["PolicyVersion"]["Document"]
+                    policy_file_json.PolicyVersion.Document()
                 )
                 policy = analyze_policy_string(
                     policy_string,
@@ -248,55 +248,55 @@ def main():
         with open(args.auth_details_file) as f:
             contents = f.read()
             auth_details_json = jsoncfg.loads_config(contents)
-            for policy in auth_details_json["Policies"]:
+            for policy in auth_details_json.Policies:
                 # Ignore AWS defined policies
-                if "arn:aws:iam::aws:" in policy["Arn"]:
+                if "arn:aws:iam::aws:" in policy.Arn():
                     continue
 
                 # Ignore AWS Service-linked roles
                 if (
-                    policy["Path"] == "/service-role/"
-                    or policy["Path"] == "/aws-service-role/"
-                    or policy["PolicyName"].startswith("AWSServiceRoleFor")
-                    or policy["PolicyName"].endswith("ServiceRolePolicy")
-                    or policy["PolicyName"].endswith("ServiceLinkedRolePolicy")
+                    policy.Path() == "/service-role/"
+                    or policy.Path() == "/aws-service-role/"
+                    or policy.PolicyName().startswith("AWSServiceRoleFor")
+                    or policy.PolicyName().endswith("ServiceRolePolicy")
+                    or policy.PolicyName().endswith("ServiceLinkedRolePolicy")
                 ):
                     continue
 
-                for version in policy["PolicyVersionList"]:
-                    if not version["IsDefaultVersion"]:
+                for version in policy.PolicyVersionList:
+                    if not version.IsDefaultVersion():
                         continue
                     policy = analyze_policy_string(
-                        json.dumps(version["Document"]), policy["Arn"],
+                        json.dumps(version.Document()), policy.Arn(),
                     )
                     findings.extend(policy.findings)
 
             # Review the inline policies on Users, Roles, and Groups
-            for user in auth_details_json["UserDetailList"]:
-                for policy in user.get("UserPolicyList", []):
+            for user in auth_details_json.UserDetailList:
+                for policy in user.UserPolicyList([]):
                     policy = analyze_policy_string(
-                        json.dumps(policy["PolicyDocument"]),
-                        user["Arn"],
+                        json.dumps(policy['PolicyDocument']),
+                        user.Arn(),
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
                         config=config,
                     )
                     findings.extend(policy.findings)
-            for role in auth_details_json["RoleDetailList"]:
-                for policy in role.get("RolePolicyList", []):
+            for role in auth_details_json.RoleDetailList:
+                for policy in role.RolePolicyList([]):
                     policy = analyze_policy_string(
-                        json.dumps(policy["PolicyDocument"]),
-                        role["Arn"],
+                        json.dumps(policy['PolicyDocument']),
+                        role.Arn(),
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
                         config=config,
                     )
                     findings.extend(policy.findings)
-            for group in auth_details_json["GroupDetailList"]:
-                for policy in group.get("GroupPolicyList", []):
+            for group in auth_details_json.GroupDetailList:
+                for policy in group.GroupPolicyList([]):
                     policy = analyze_policy_string(
-                        json.dumps(policy["PolicyDocument"]),
-                        group["Arn"],
+                        json.dumps(policy['PolicyDocument']),
+                        group.Arn(),
                         private_auditors_custom_path=args.private_auditors,
                         include_community_auditors=args.include_community_auditors,
                         config=config,


### PR DESCRIPTION
This fixes the syntax for json-cfg when running --aws-managed-policies and --auth-details-file

Before this commit you would get an error similar to the following:

        jsoncfg.config_classes.JSONConfigNodeTypeError: Expected a ConfigJSONObject but found
        ConfigJSONScalar. You are trying to access the __contains__ magic method of a scalar
        config object.

It seems that instead of treating the json-cfg objects as hash's you're supposed to access keys
via attributes and use a method call when you want to convert it back into it's original form.

Passing an argument to this method call sets the default return, acting similar to:

        obj.get('key', default)