### PR TITLE
Add RESOURCE_EFFECTIVELY_STAR check

### DIFF
--- a/parliament/config.yaml
+++ b/parliament/config.yaml
@@ -115,6 +115,12 @@ RESOURCE_STAR:
   severity: LOW
   group: MALFORMED
 
+RESOURCE_EFFECTIVELY_STAR:
+  title: Unnecessary use of Resource * based on wildcards
+  description: "Resource block is functionally equivalent to Resource *"
+  severity: LOW
+  group: MALFORMED
+
 UNKNOWN_OPERATOR:
   title: The condition operator is unknown.
   severity: MEDIUM


### PR DESCRIPTION
This check warns users when the combined scope of all Resource specifiers effectively spans "*". We infer this check by seeing if there is a wildcard Resource for every service that could possibly be manipulated by the statement Actions.

It's still straightforward to circumvent this check by adding a partition or an AWS account ID. Another way to circumvent this check is by "expanding" a single Resource specifier into 3 separate partition identifiers.

I didn't put this in community_auditors since it seemed closely linked to RESOURCE_STAR, however, I also didn't make this RESOURCE_STAR because that check is for explicit "*" and can be associated with a particular Action (whereas this check applies to the intersection of all Actions).

Fixes #106 