### PR TITLE
fix private auditors custom path

### DIFF
--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -209,9 +209,6 @@ def main():
 
     logging.basicConfig(level=log_level, stream=sys.stderr, format=log_format)
 
-    if args.private_auditors is not None and "." in args.private_auditors:
-        raise Exception("The path to the private_auditors must not have periods")
-
     if args.minimal and args.json:
         raise Exception("You cannot choose both minimal and json output")
 


### PR DESCRIPTION
Thanks for writing this awesome library!! I've been working thoroughly with parliament and have discovered a few issues with how the custom path for the private auditors directory is currently specified:

1. Does not allow paths with "." - for example, `/Users/foo.bar/private_auditors` would be rejected

2. Does not allow sourcing from absolute paths - `/Users/foo/parliament/private_auditors` is converted to the string `.Users.foo.parliament.private_auditors` and fails to evaluate to a package for a variety of reasons 

3. Does not allow sourcing from arbitrary paths - At my company, we want to create a thin wrapper around parliament that defaults to our configuration and private auditors. This means storing private auditors in the wrapper package and referencing them dynamically. There are many places a user could install our package on their file system. The way that parliament currently evaluates the custom private auditors path does not work with all paths.

Tests are a bit difficult to write for this (and parliament doesn't have an already existing suite of tests for this case). If you want to test these changes locally, install this version and:

```
parliament --file policy --private_auditors {relative_path}
parliament --file policy --private_auditors {absolute_path}
```