### PR TITLE
Change RESOURCE_STAR group to NOT_IDEAL

### DIFF
--- a/parliament/config.yaml
+++ b/parliament/config.yaml
@@ -113,7 +113,7 @@ RESOURCE_MISMATCH:
 RESOURCE_STAR:
   title: Unnecessary use of Resource *
   severity: LOW
-  group: MALFORMED
+  group: NOT_IDEAL
 
 UNKNOWN_OPERATOR:
   title: The condition operator is unknown.


### PR DESCRIPTION
Instead of MALFORMED


(GitHub web UI added the newline, but no objections there.)