### PR TITLE
Add check for using condition set operators with single-valued condition keys

### DIFF
--- a/parliament/community_auditors/config_override.yaml
+++ b/parliament/community_auditors/config_override.yaml
@@ -36,3 +36,9 @@ NOTRESOURCE_WITH_ALLOW:
   description: NotResource with Allow automatically grants the Principal all services and resources that are not explicitly listed
   severity: MEDIUM
   group: CUSTOM
+
+SINGLE_VALUE_CONDITION_TOO_PERMISSIVE:
+  title: A single value conditional is checked against a set of values
+  description: Checking a single value conditional key against a set of values results in overly permissive policies.
+  severity: MEDIUM
+  group: CUSTOM

--- a/parliament/community_auditors/single_value_condition_too_permissive.py
+++ b/parliament/community_auditors/single_value_condition_too_permissive.py
@@ -1,0 +1,59 @@
+"""
+For AWS policies using conditionals, checking a single valued condition key with a check
+designed for multi-value condition keys results in "overly permissive policies"
+https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_single-vs-multi-valued-condition-keys.html
+"""
+import re
+from parliament import Policy
+from parliament.misc import make_list
+
+def audit(policy: Policy) -> None:
+    global_single_valued_condition_keys = [
+        "aws:CalledViaFirst",
+        "aws:CalledViaLast",
+        "aws:CurrentTime",
+        "aws:EpochTime",
+        "aws:FederatedProvider",
+        "aws:MultiFactorAuthAge",
+        "aws:MultiFactorAuthPresent",
+        "aws:PrincipalAccount",
+        "aws:PrincipalArn",
+        "aws:PrincipalIsAWSService",
+        "aws:PrincipalOrgID",
+        "aws:PrincipalServiceName",
+        "aws:PrincipalTag",
+        "aws:PrincipalType",
+        "aws:referer",
+        "aws:RequestedRegion",
+        "aws:RequestTag/*",
+        "aws:ResourceTag/*",
+        "aws:SecureTransport",
+        "aws:SourceAccount",
+        "aws:SourceArn",
+        "aws:SourceIdentity",
+        "aws:SourceIp",
+        "aws:SourceVpc",
+        "aws:SourceVpce",
+        "aws:TokenIssueTime",
+        "aws:UserAgent",
+        "aws:userid",
+        "aws:username",
+        "aws:ViaAWSService",
+        "aws:VpcSourceIp",
+    ]
+
+    for stmt in policy.statements:
+        conditions = make_list(stmt.stmt["Condition"])
+        
+        for condition in conditions[0]:
+            # The operator is the first element (ex. `StringLike`) and the condition_block follows it
+            operator = condition[0]
+            condition_block = condition[1]
+            if re.match(r"^For(All|Any)Values:", operator):
+                keys = list(k for k,_v in condition_block)
+                if any(any(re.match(k, key) for k in global_single_valued_condition_keys) for key in keys):
+                    policy.add_finding(
+                        "SINGLE_VALUE_CONDITION_TOO_PERMISSIVE",
+                        detail='Checking a single value conditional key against a set of values results in overly permissive policies.',
+                    )
+                    print("match")

--- a/parliament/community_auditors/tests/test_single_value_condition_too_permissive.py
+++ b/parliament/community_auditors/tests/test_single_value_condition_too_permissive.py
@@ -1,0 +1,35 @@
+import unittest
+
+from nose.tools import assert_equal
+
+from parliament import analyze_policy_string
+
+
+class TestSensitiveAccess(unittest.TestCase):
+    """Test class for single value condition too permissive auditor"""
+    example_policy_string = """
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "s3:GetObject"
+              ],
+              "Resource": "arn:aws:s3:::secretbucket/*",
+              "Condition": {
+                  "ForAllValues:StringEquals": {
+                      "aws:ResourceTag/Tag": [
+                          "Value"
+                      ]
+
+                  }
+              }
+            }
+          ]
+        }
+    """
+    policy = analyze_policy_string(
+        example_policy_string, include_community_auditors=True
+    )
+    assert_equal(policy.finding_ids, set(["SINGLE_VALUE_CONDITION_TOO_PERMISSIVE"]))


### PR DESCRIPTION
As per [this help article](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_single-vs-multi-valued-condition-keys.html) they "can lead to overly permissive policies"