### PR TITLE
use file option only when directory is not used

### DIFF
--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -314,7 +314,7 @@ def main():
             config=config,
         )
         findings.extend(policy.findings)
-    elif args.file:
+    elif args.file and not args.directory:
         contents = args.file.read()
         args.file.close()
         policy = analyze_policy_string(


### PR DESCRIPTION
In version 1.4.1 the --directory flag causes parliament to hang. There was a code change to make the default option for --file to be sys.stdin, making args.file always evaluate truthy. Since the args.file flag check comes before the args.directory check, the directory option is never used when specified.

This change adds a condition to the args.file path the only executes it when args.directory is not specified.

fixes #198 