### PR TITLE
:bug: Fix pkgutil.iter_modules call

### DIFF
--- a/parliament/policy.py
+++ b/parliament/policy.py
@@ -331,7 +331,7 @@ class Policy:
         if include_community_auditors is True:
             # Import any private auditing modules
             community_auditors_directory = "community_auditors"
-            community_auditors_directory_path = (
+            community_auditors_directory_path = str(
                 Path(os.path.abspath(__file__)).parent / community_auditors_directory
             )
 


### PR DESCRIPTION
Give a list of str rather than a list of PosixPath

On Python 3.9.5:
```
>>> import email
>>> email.__path__
['/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/email']
>>> email.__path__[0]
'/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/email'
>>> type(email.__path__[0])
<class 'str'>
```

The [pkgutil.iter_modules](https://docs.python.org/3/library/pkgutil.html#pkgutil.iter_modules) docs are pretty bad on this:
`path should be either None or a list of paths to look for modules in.`
it doesn't specify string.

You can see a lot of other OSS projects have had bugs like this:
- https://github.com/n1ngu/faker/commit/c37017643327d30033112e8dd837046a8c740ed7
- https://github.com/simongrest/farm-pin-crop-detection-challenge/issues/2
etc.


Stack trace for posterity was:
```
  File "/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/site-packages/parliament/__init__.py", line 69, in analyze_policy_string
    policy.analyze(
  File "/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/site-packages/parliament/policy.py", line 339, in analyze
    for importer, name, _ in pkgutil.iter_modules(
  File "/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/pkgutil.py", line 130, in iter_modules
    for i in importers:
  File "/Users/kevinhock/.pyenv/versions/3.9.5/lib/python3.9/pkgutil.py", line 420, in get_importer
    importer = path_hook(path_item)
  File "<frozen importlib._bootstrap_external>", line 1601, in path_hook_for_FileFinder
  File "<frozen importlib._bootstrap_external>", line 1476, in __init__
  File "<frozen importlib._bootstrap_external>", line 177, in _path_isabs
AttributeError: 'PosixPath' object has no attribute 'startswith'
```