### PR TITLE
Add additional action to credentials exposure community auditor

### DIFF
--- a/parliament/community_auditors/credentials_exposure.py
+++ b/parliament/community_auditors/credentials_exposure.py
@@ -26,6 +26,7 @@ CREDENTIALS_EXPOSURE_ACTIONS = [
     "sts:assumerolewithwebidentity",
     "sts:getfederationtoken",
     "sts:getsessiontoken",
+    "cognito-idp:describeuserpoolclient",
 ]
 
 


### PR DESCRIPTION
The 'cognito-idp:DescribeUserPoolClient' API action includes OAuth Client Secrets in it's response, so although the action doesn't return AWS credentials, should this be something that gets flagged for credentials exposure?