### PR TITLE
Fix missing import in statement.py

### DIFF
--- a/parliament/statement.py
+++ b/parliament/statement.py
@@ -1,3 +1,4 @@
+import json
 import jsoncfg
 import re
 


### PR DESCRIPTION
When looping through statements I found that the __repr__ function uses json library which is not imported.