### PR TITLE
Fix #217 Cast PathObj as string

### DIFF
--- a/parliament/policy.py
+++ b/parliament/policy.py
@@ -337,7 +337,7 @@ class Policy:
 
             community_auditors = {}
             for importer, name, _ in pkgutil.iter_modules(
-                [community_auditors_directory_path]
+                [str(community_auditors_directory_path)]
             ):
                 full_package_name = "parliament.%s.%s" % (
                     community_auditors_directory,


### PR DESCRIPTION
Unit Test: `make test` passed
Manual Test: ` ./bin/parliament --include-community-auditors --file ~/test/parliament/allow_not_principal.json` passed

The test file isn't very import, just to make sure `include-community-auditors` does not have an issue.

Tested under Python 3.9.13 since BeautifulSoup is not compatible with Python 3.10 yet. The fix should allow parliament library to be usable with Python 3.10.