### PR TITLE
feat(cli): Support --files

### DIFF
--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -120,7 +120,7 @@ def find_files(directory, exclude_pattern=None, policy_extension=""):
     return discovered_files
 
 
-def main():
+def main(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--aws-managed-policies",
@@ -200,7 +200,7 @@ def main():
         action="version",
         version="%(prog)s {version}".format(version=__version__),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args=argv[1:])
 
     log_level = logging.ERROR
     log_format = "%(message)s"
@@ -226,7 +226,6 @@ def main():
         parser.error("You cannot pass files with both --file and --files together")
 
     # Change the exit status if there are errors
-    exit_status = 0
     findings = []
 
     if args.include_community_auditors:
@@ -364,7 +363,7 @@ def main():
                 findings.extend(policy.findings)
     else:
         parser.print_help()
-        exit(-1)
+        return -1
 
     filtered_findings = []
     for finding in findings:
@@ -374,14 +373,18 @@ def main():
 
     if len(filtered_findings) == 0:
         # Return with exit code 0 if no findings
-        return
+        return 0
 
     for finding in filtered_findings:
         print_finding(finding, args.minimal, args.json)
 
     # There were findings, so return with a non-zero exit code
-    exit(1)
+    return 1
+
+
+def cli() -> int:
+    sys.exit(main(sys.argv))
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/parliament/cli.py
+++ b/parliament/cli.py
@@ -121,6 +121,8 @@ def find_files(directory, exclude_pattern=None, policy_extension=""):
 
 
 def main(argv):
+    with open("/tmp/parliament.log", "w") as fout:
+        fout.write(f"Argv: {argv}\n")
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--aws-managed-policies",
@@ -201,6 +203,9 @@ def main(argv):
         version="%(prog)s {version}".format(version=__version__),
     )
     args = parser.parse_args(args=argv[1:])
+
+    with open("/tmp/parliament.log", "a") as fout:
+        fout.write(f"Files: {args.files}\n")
 
     log_level = logging.ERROR
     log_format = "%(message)s"
@@ -325,6 +330,8 @@ def main(argv):
         for file_path in (stripped_path for path in args.files.split(",") if (stripped_path := path.strip())):
             path = Path(file_path)
             contents = path.read_text()
+            with open("/tmp/parliament.log", "a") as fout:
+                fout.write(f"Path: {path}\nContents: {contents}\n")
             policy = analyze_policy_string(
                 contents,
                 file_path,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     long_description=get_description(),
     long_description_content_type="text/markdown",
     url="https://github.com/duo-labs/parliament",
-    entry_points={"console_scripts": "parliament=parliament.cli:main"},
+    entry_points={"console_scripts": "parliament=parliament.cli:cli"},
     test_suite="tests/unit",
     tests_require=TESTS_REQUIRE,
     extras_require={"dev": TESTS_REQUIRE + ["autoflake", "autopep8", "pylint"]},


### PR DESCRIPTION
Hi!

This merge request implements a `--files` command-line argument that allows passing a list of policies to analyse.

The signature of the `main()` function was also modified to get `argv` as an argument, instead of assuming `sys.argv`.

Both changes are necessary to implement a `pre-commit` hook I’ve been using locally.

I may make the repository public if this patch is merged, for the sake of further contributing!