### PR TITLE
Add a realistic user-agent to avoid WAF for util

### DIFF
--- a/utils/update_iam_data.py
+++ b/utils/update_iam_data.py
@@ -15,7 +15,11 @@ BASE_DOCUMENTATION_URL = "https://docs.aws.amazon.com/service-authorization/late
 
 def get_links_from_base_actions_resources_conditions_page():
     """Gets the links from the actions, resources, and conditions keys page, and returns their filenames."""
-    html = requests.get(BASE_DOCUMENTATION_URL)
+    
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
+    }
+    html = requests.get(BASE_DOCUMENTATION_URL, headers=headers)
     soup = BeautifulSoup(html.content, "html.parser")
     html_filenames = []
     for i in soup.find("div", {"class": "highlights"}).findAll("a"):


### PR DESCRIPTION
The AWS endpoint has started to respond with a 405 Not Allowed and a CAPTCHA verification for the default user agent when requesting the data, at least when calling from GitHub Actions. Using a realistic user agent seems to combat this.