### PR TITLE
Update user agent to avoid Amazon's wrath

### DIFF
--- a/utils/update_iam_data.py
+++ b/utils/update_iam_data.py
@@ -17,7 +17,7 @@ def get_links_from_base_actions_resources_conditions_page():
     """Gets the links from the actions, resources, and conditions keys page, and returns their filenames."""
     
     headers = {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
     }
     html = requests.get(BASE_DOCUMENTATION_URL, headers=headers)
     soup = BeautifulSoup(html.content, "html.parser")


### PR DESCRIPTION
AWS are getting annoying against scrapers once again, throwing a HTTP 405 only if you use the exact user agent specified currently. Bumping seems to avoid this.